### PR TITLE
added the intern and first unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ extras/feature-collection-shell.js:  JSON template for creating a feature collec
 See index.html for links to demos. This repo isn't set up for gh-pages since the useful demos require https.
 
 Tested in Chrome. No IE support as it relies on CORS to do a cross-domain POST to arcgis.com.
+
+To run unit tests, first run `npm install` at the command line. Then open a browser and enter the following URL:
+
+http://host/path/to/cereal/node_modules/intern/client.html?config=tests/intern
+
+Test results will appear in the console window.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "cereal",
+  "version": "0.0.1",
+  "description": "Attempt at creating a classes to serialize and write a JS API map to arcgis.com.",
+  "main": "index.html",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swingley/cereal.git"
+  },
+  "keywords": [
+    "arcgis",
+    "javascript",
+    "webmap",
+    "json",
+    "serialization"
+  ],
+  "author": "Derek Swingley",
+  "license": "Apache",
+  "bugs": {
+    "url": "https://github.com/swingley/cereal/issues"
+  },
+  "homepage": "https://github.com/swingley/cereal",
+  "devDependencies": {
+    "intern": "^1.7.0"
+  }
+}

--- a/tests/image.js
+++ b/tests/image.js
@@ -1,0 +1,101 @@
+define([
+  'intern!bdd',
+  'intern/chai!expect',
+
+  'dojo/Deferred',
+  'dojo/dom-construct',
+
+  'esri/map',
+  'esri/layers/ArcGISImageServiceLayer',
+  'esri/layers/ImageServiceParameters',
+
+  'extras/map-cereal'
+], function (
+  bdd, expect,
+  Deferred, domConstruct,
+  Map, ArcGISImageServiceLayer, ImageServiceParameters,
+  Cereal
+) {
+  bdd.describe('image servies', function () {
+    var map;
+    var layer;
+    var cereal;
+    var webmap;
+
+    // add map to page and add layer to map
+    // when layer loads, serialize webmap
+    bdd.before(function () {
+      var dfd = new Deferred();
+      var mapDiv = domConstruct.place('<div id="map"></div>', document.body);
+      map = new Map(mapDiv, {
+        basemap: "topo",
+        center: [-79.40, 43.64],
+        zoom: 12
+      });
+      var params = new ImageServiceParameters();
+      params.noData = 0;
+      layer = new ArcGISImageServiceLayer("http://sampleserver6.arcgisonline.com/arcgis/rest/services/Toronto/ImageServer", {
+        id: 'image-service',
+        imageServiceParameters: params,
+        opacity: 0.75
+      });
+      layer.on('load', function(e) {
+        dfd.resolve(layer);
+      });
+      map.addLayer(layer);
+      cereal = new Cereal({
+        map: map
+      });
+      webmap = cereal._serialize(map);
+      return dfd.promise;
+    });
+
+    // bdd.beforeEach(function() {
+    // });
+
+    bdd.after(function () {
+      cereal = null;
+      map.destroy();
+      layer = null;
+      webmap = null;
+      domConstruct.empty(document.body);
+    });
+
+    bdd.it('should have exactly 1 operationalLayers', function () {
+      expect(webmap.operationalLayers).to.be.ok;
+      expect(webmap.operationalLayers.length).to.equal(1);
+    });
+
+    bdd.describe('layer JSON', function() {
+      var layerJson;
+
+      bdd.before(function() {
+        layerJson = webmap.operationalLayers[0];
+      });
+
+      bdd.it('should have same id', function () {
+        expect(layerJson.id).to.equal(layer.id);
+      });
+
+      bdd.it('should have same url', function () {
+        expect(layerJson.url).to.equal(layer.url);
+      });
+
+      bdd.it('should have same opacity', function () {
+        expect(layerJson.opacity).to.equal(layer.opacity);
+      });
+
+      bdd.it('should have same visibility', function () {
+        expect(layerJson.visibility).to.equal(layer.visible);
+      });
+
+      bdd.it('should not have a renderingRule unless defined', function () {
+        if (layer.renderingRule) {
+          expect(layerJson.renderingRule).to.equal(layer.renderingRule.toJson());
+        } else {
+          expect(layerJson.renderingRule).to.not.be.ok;
+        }
+      });
+    });
+  });
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,0 +1,88 @@
+// Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
+// These default settings work OK for most people. The options that *must* be changed below are the
+// packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
+define({
+
+	// The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
+	// loader
+	useLoader: {
+		'host-browser': 'http://js.arcgis.com/3.9/'
+	},
+
+	// Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
+	// can be used here
+	loader: {
+		// Packages that should be registered with the loader in each testing environment
+		packages: [{
+		  name: 'tests',
+		  location: 'tests'
+		}, {
+		  name: 'extras',
+		  location: 'extras'
+		}, {
+		  name: 'esri',
+		  location: 'http://js.arcgis.com/3.9/js/esri'
+		}, {
+		  name: 'dojo',
+		  location: 'http://js.arcgis.com/3.9/js/dojo/dojo'
+		}, {
+		  name: 'dojox',
+		  location: 'http://js.arcgis.com/3.9/js/dojo/dojox'
+		}, {
+		  name: 'dijit',
+		  location: 'http://js.arcgis.com/3.9/js/dojo/dijit'
+		}]
+	},
+
+  // Non-functional test suite(s) to run in each browser
+  suites: [ 'tests/image' ]//,
+
+  // NOTE: no need for configuration settings related to functional testing
+  // not possible with a remotedly hosted dojo loader (http://js.arcgis.com/3.9/)
+
+  // // The port on which the instrumenting proxy will listen
+  // proxyPort: 9000,
+
+  // // A fully qualified URL to the Intern proxy
+  // proxyUrl: 'http://localhost:9000/',
+
+  // // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
+  // // specified browser environments in the `environments` array below as well. See
+  // // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
+  // // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
+  // // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
+  // // automatically
+  // capabilities: {
+  //   'selenium-version': '2.39.0',
+  //   'idle-timeout': 30
+  // },
+
+  // // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+  // // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+  // // capabilities options specified for an environment will be copied as-is
+  // environments: [
+  //   { browserName: 'firefox' },
+  //   { browserName: 'safari' },
+  //   { browserName: 'chrome' }
+  // ],
+
+  // // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+  // maxConcurrency: 3,
+
+  // // Whether or not to start Sauce Connect before running tests
+  // useSauceConnect: false,
+
+  // // Connection information for the remote WebDriver service. If using Sauce Labs, keep your username and password
+  // // in the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables unless you are sure you will NEVER be
+  // // publishing this configuration file somewhere
+  // webdriver: {
+  //   host: 'localhost',
+  //   port: 4444
+  // },
+
+	// // Functional test suite(s) to run in each browser once non-functional tests are completed
+	// functionalSuites: [],
+
+	// A regular expression matching URLs to files that should not be included in code coverage analysis
+	// excludeInstrumentation: /^(?:tests|node_modules)\//
+});


### PR DESCRIPTION
I got intern running in-browser unit tests based on @DavidSpriggs's [Esri Intern tutorial](https://github.com/DavidSpriggs/intern-tutorial-esri-jsapi).

I wrote one suite to test serializing image services. This pattern can be copied to test the other serialization methods.

I added instructions to README on how to install intern (`npm install`) and run the tests in a browser.
